### PR TITLE
Fix objects not being deselected on undo of creation or removal of parent

### DIFF
--- a/WallyMapEditor/src/Commands/ArrayAddCommand.cs
+++ b/WallyMapEditor/src/Commands/ArrayAddCommand.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace WallyMapEditor;
+
+public class ArrayAddCommand<T>(Action<T[]> arrayChange, T[] array, T toAdd)
+    : PropChangeCommand<T[]>(arrayChange, array, [.. array, toAdd]), IDeselectCommand where T : notnull
+{
+    public bool ShouldDeselect(SelectionContext selection) => selection.Object == (object)toAdd;
+}

--- a/WallyMapEditor/src/Commands/ArrayAddCommand.cs
+++ b/WallyMapEditor/src/Commands/ArrayAddCommand.cs
@@ -5,5 +5,6 @@ namespace WallyMapEditor;
 public class ArrayAddCommand<T>(Action<T[]> arrayChange, T[] array, T toAdd)
     : PropChangeCommand<T[]>(arrayChange, array, [.. array, toAdd]), IDeselectCommand where T : notnull
 {
-    public bool ShouldDeselect(SelectionContext selection) => selection.Object == (object)toAdd;
+    public bool DeselectOnUndo(SelectionContext selection) => selection.Object == (object)toAdd || selection.IsChildOf(toAdd);
+    public bool DeselectOnExecute(SelectionContext selection) => false;
 }

--- a/WallyMapEditor/src/Commands/ArrayRemoveCommand.cs
+++ b/WallyMapEditor/src/Commands/ArrayRemoveCommand.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace WallyMapEditor;
+
+public class ArrayRemoveCommand<T>(Action<T[]> arrayChange, T[] removedArray, T removedValue)
+    : PropChangeCommand<T[]>(arrayChange, [.. removedArray, removedValue], removedArray), IDeselectCommand where T : notnull
+{
+    public bool DeselectOnUndo(SelectionContext selection) => false;
+    public bool DeselectOnExecute(SelectionContext selection) => selection.Object == (object)removedValue || selection.IsChildOf(removedValue);
+}

--- a/WallyMapEditor/src/Commands/CommandHistory.cs
+++ b/WallyMapEditor/src/Commands/CommandHistory.cs
@@ -18,10 +18,13 @@ public class CommandHistory
         Commands.Push(cmd);
     }
 
-    public void Undo()
+    public void Undo(SelectionContext selection)
     {
         if (Commands.TryPop(out ICommand? prev))
         {
+            if (prev is IDeselectCommand d && d.ShouldDeselect(selection))
+                selection.Object = null;
+
             prev.Undo();
             Undone.Push(prev);
         }

--- a/WallyMapEditor/src/Commands/IDeselectCommand.cs
+++ b/WallyMapEditor/src/Commands/IDeselectCommand.cs
@@ -2,5 +2,6 @@ namespace WallyMapEditor;
 
 public interface IDeselectCommand : ICommand
 {
-    public bool ShouldDeselect(SelectionContext selection);
+    public bool DeselectOnUndo(SelectionContext selection);
+    public bool DeselectOnExecute(SelectionContext selection);
 }

--- a/WallyMapEditor/src/Commands/IDeselectCommand.cs
+++ b/WallyMapEditor/src/Commands/IDeselectCommand.cs
@@ -1,0 +1,6 @@
+namespace WallyMapEditor;
+
+public interface IDeselectCommand : ICommand
+{
+    public bool ShouldDeselect(SelectionContext selection);
+}

--- a/WallyMapEditor/src/Editor.cs
+++ b/WallyMapEditor/src/Editor.cs
@@ -170,7 +170,7 @@ public class Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault
             Selection.Object = null;
 
         if (HistoryPanel.Open)
-            HistoryPanel.Show(CommandHistory);
+            HistoryPanel.Show(CommandHistory, Selection);
         if (PlaylistEditPanel.Open && MapData is Level lv)
             PlaylistEditPanel.Show(lv, PathPrefs);
 
@@ -204,7 +204,7 @@ public class Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault
         }
         if (ImGui.BeginMenu("Edit"))
         {
-            if (ImGui.MenuItem("Undo", "Ctrl+Z")) CommandHistory.Undo();
+            if (ImGui.MenuItem("Undo", "Ctrl+Z")) CommandHistory.Undo(Selection);
             if (ImGui.MenuItem("Redo", "Ctrl+Y")) CommandHistory.Redo();
             if (ImGui.MenuItem("Deselect", "Ctrl+D")) Selection.Object = null;
             ImGui.EndMenu();
@@ -268,7 +268,7 @@ public class Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault
 
         if (!wantCaptureKeyboard && Rl.IsKeyDown(KeyboardKey.LeftControl))
         {
-            if (Rl.IsKeyPressed(KeyboardKey.Z)) CommandHistory.Undo();
+            if (Rl.IsKeyPressed(KeyboardKey.Z)) CommandHistory.Undo(Selection);
             if (Rl.IsKeyPressed(KeyboardKey.Y)) CommandHistory.Redo();
             if (Rl.IsKeyPressed(KeyboardKey.D)) Selection.Object = null;
             if (ImportDialog.CanReImport() && Rl.IsKeyPressed(KeyboardKey.R)) ImportDialog.ReImport(this);

--- a/WallyMapEditor/src/Editor.cs
+++ b/WallyMapEditor/src/Editor.cs
@@ -12,7 +12,7 @@ using NativeFileDialogSharp;
 
 namespace WallyMapEditor;
 
-public class Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault)
+public class Editor
 {
     public const string WINDOW_NAME = "WallyMapEditor";
     public const float ZOOM_INCREMENT = 0.15f;
@@ -22,8 +22,8 @@ public class Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault
     public const int INITIAL_SCREEN_WIDTH = 800;
     public const int INITIAL_SCREEN_HEIGHT = 480;
 
-    PathPreferences PathPrefs { get; } = pathPrefs;
-    RenderConfigDefault ConfigDefault { get; } = configDefault;
+    PathPreferences PathPrefs { get; }
+    RenderConfigDefault ConfigDefault { get; }
 
     public IDrawable? MapData { get; set; }
     public BoneTypes? BoneTypes { get; set; }
@@ -38,12 +38,12 @@ public class Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault
     public RenderConfigWindow RenderConfigWindow { get; set; } = new();
     public MapOverviewWindow MapOverviewWindow { get; set; } = new();
     public PropertiesWindow PropertiesWindow { get; set; } = new();
-    public ExportWindow ExportDialog { get; set; } = new(pathPrefs);
-    public ImportWindow ImportDialog { get; set; } = new(pathPrefs);
+    public ExportWindow ExportDialog { get; set; }
+    public ImportWindow ImportDialog { get; set; }
 
     public OverlayManager OverlayManager { get; set; } = new();
-    public CommandHistory CommandHistory { get; set; } = new();
     public SelectionContext Selection { get; set; } = new();
+    public CommandHistory CommandHistory { get; set; }
 
     private readonly RenderConfig _renderConfig = RenderConfig.Default;
     private readonly OverlayConfig _overlayConfig = OverlayConfig.Default;
@@ -53,6 +53,10 @@ public class Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault
     public MousePickingFramebuffer PickingFramebuffer { get; set; } = new();
 
     private bool _showMainMenuBar = true;
+
+    public Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault) =>
+        (PathPrefs, ConfigDefault, CommandHistory, ExportDialog, ImportDialog) =
+            (pathPrefs, configDefault, new(Selection), new(pathPrefs), new(pathPrefs));
 
     private OverlayData OverlayData => new()
     {
@@ -204,7 +208,7 @@ public class Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault
         }
         if (ImGui.BeginMenu("Edit"))
         {
-            if (ImGui.MenuItem("Undo", "Ctrl+Z")) CommandHistory.Undo(Selection);
+            if (ImGui.MenuItem("Undo", "Ctrl+Z")) CommandHistory.Undo();
             if (ImGui.MenuItem("Redo", "Ctrl+Y")) CommandHistory.Redo();
             if (ImGui.MenuItem("Deselect", "Ctrl+D")) Selection.Object = null;
             ImGui.EndMenu();
@@ -268,7 +272,7 @@ public class Editor(PathPreferences pathPrefs, RenderConfigDefault configDefault
 
         if (!wantCaptureKeyboard && Rl.IsKeyDown(KeyboardKey.LeftControl))
         {
-            if (Rl.IsKeyPressed(KeyboardKey.Z)) CommandHistory.Undo(Selection);
+            if (Rl.IsKeyPressed(KeyboardKey.Z)) CommandHistory.Undo();
             if (Rl.IsKeyPressed(KeyboardKey.Y)) CommandHistory.Redo();
             if (Rl.IsKeyPressed(KeyboardKey.D)) Selection.Object = null;
             if (ImportDialog.CanReImport() && Rl.IsKeyPressed(KeyboardKey.R)) ImportDialog.ReImport(this);

--- a/WallyMapEditor/src/Gui/ImGuiExtensions.cs
+++ b/WallyMapEditor/src/Gui/ImGuiExtensions.cs
@@ -437,8 +437,7 @@ public static class ImGuiExt
         Maybe<T> maybeNewValue = create();
         if (maybeNewValue.TryGetValue(out T? newValue))
         {
-            T[] result = [.. values, newValue];
-            commands.Add((new PropChangeCommand<T[]>(changeCommand, values, result), false));
+            commands.Add((new ArrayAddCommand<T>(changeCommand, values, newValue), false));
             changed = true;
         }
 

--- a/WallyMapEditor/src/Gui/ImGuiExtensions.cs
+++ b/WallyMapEditor/src/Gui/ImGuiExtensions.cs
@@ -411,7 +411,7 @@ public static class ImGuiExt
             if (WithDisabledButton(!allowRemove, $"Remove##{value.GetHashCode()}"))
             {
                 T[] result = WmeUtils.RemoveAt(values, i);
-                commands.Add((new PropChangeCommand<T[]>(changeCommand, values, result), false));
+                commands.Add((new ArrayRemoveCommand<T>(changeCommand, result, value), false));
                 changed = true;
             }
             if (allowMove)
@@ -441,7 +441,7 @@ public static class ImGuiExt
             changed = true;
         }
 
-        foreach ((PropChangeCommand<T[]> command, bool mergeable) in commands)
+        foreach ((ICommand command, bool mergeable) in commands)
         {
             cmd.Add(command);
             cmd.SetAllowMerge(mergeable);

--- a/WallyMapEditor/src/Gui/Popups/AddObjectPopup.cs
+++ b/WallyMapEditor/src/Gui/Popups/AddObjectPopup.cs
@@ -110,28 +110,28 @@ public static class AddObjectPopup
 
     public static void AddDynamicItemSpawnMenuHistory(Vector2 pos, Level l, SelectionContext selection, CommandHistory cmd) =>
         AddObjectWithDynamicMenuHistory<AbstractItemSpawn, DynamicItemSpawn>(pos, "DynamicItemSpawn", AddItemSpawnMenu,
-            newVal => cmd.Add(new PropChangeCommand<AbstractItemSpawn[]>(val => l.Desc.ItemSpawns = val, l.Desc.ItemSpawns, [.. l.Desc.ItemSpawns, newVal])),
-            newVal => cmd.Add(new PropChangeCommand<DynamicItemSpawn[]>(val => l.Desc.DynamicItemSpawns = val, l.Desc.DynamicItemSpawns, [.. l.Desc.DynamicItemSpawns, newVal])),
+            newVal => cmd.Add(new ArrayAddCommand<AbstractItemSpawn>(val => l.Desc.ItemSpawns = val, l.Desc.ItemSpawns, newVal)),
+            newVal => cmd.Add(new ArrayAddCommand<DynamicItemSpawn>(val => l.Desc.DynamicItemSpawns = val, l.Desc.DynamicItemSpawns, newVal)),
             selection, cmd);
 
     public static void AddDynamicRespawnMenuHistory(Vector2 pos, Level l, SelectionContext selection, CommandHistory cmd) =>
         AddObjectWithDynamicMenuHistory<Respawn, DynamicRespawn>(pos, "DynamicRespawn",
             position => ImGui.MenuItem("Respawn") ? PropertiesWindow.DefaultRespawn(position) : Maybe<Respawn>.None,
-            newVal => cmd.Add(new PropChangeCommand<Respawn[]>(val => l.Desc.Respawns = val, l.Desc.Respawns, [.. l.Desc.Respawns, newVal])),
-            newVal => cmd.Add(new PropChangeCommand<DynamicRespawn[]>(val => l.Desc.DynamicRespawns = val, l.Desc.DynamicRespawns, [.. l.Desc.DynamicRespawns, newVal])),
+            newVal => cmd.Add(new ArrayAddCommand<Respawn>(val => l.Desc.Respawns = val, l.Desc.Respawns, newVal)),
+            newVal => cmd.Add(new ArrayAddCommand<DynamicRespawn>(val => l.Desc.DynamicRespawns = val, l.Desc.DynamicRespawns, newVal)),
             selection, cmd);
 
     public static void AddDynamicCollisionMenuHistory(Vector2 pos, Level l, SelectionContext selection, CommandHistory cmd) =>
         AddObjectWithDynamicMenuHistory<AbstractCollision, DynamicCollision>(pos, "DynamicCollision", AddCollisionMenu,
-            newVal => cmd.Add(new PropChangeCommand<AbstractCollision[]>(val => l.Desc.Collisions = val, l.Desc.Collisions, [.. l.Desc.Collisions, newVal])),
-            newVal => cmd.Add(new PropChangeCommand<DynamicCollision[]>(val => l.Desc.DynamicCollisions = val, l.Desc.DynamicCollisions, [.. l.Desc.DynamicCollisions, newVal])),
+            newVal => cmd.Add(new ArrayAddCommand<AbstractCollision>(val => l.Desc.Collisions = val, l.Desc.Collisions, newVal)),
+            newVal => cmd.Add(new ArrayAddCommand<DynamicCollision>(val => l.Desc.DynamicCollisions = val, l.Desc.DynamicCollisions, newVal)),
             selection, cmd);
 
     public static void AddDynamicNavNodeMenuHistory(Vector2 pos, Level l, SelectionContext selection, CommandHistory cmd) =>
         AddObjectWithDynamicMenuHistory<NavNode, DynamicNavNode>(pos, "DynamicNavNode",
             position => ImGui.MenuItem("NavNode") ? PropertiesWindow.DefaultNavNode(position, l.Desc) : Maybe<NavNode>.None,
-            newVal => cmd.Add(new PropChangeCommand<NavNode[]>(val => l.Desc.NavNodes = val, l.Desc.NavNodes, [.. l.Desc.NavNodes, newVal])),
-            newVal => cmd.Add(new PropChangeCommand<DynamicNavNode[]>(val => l.Desc.DynamicNavNodes = val, l.Desc.DynamicNavNodes, [.. l.Desc.DynamicNavNodes, newVal])),
+            newVal => cmd.Add(new ArrayAddCommand<NavNode>(val => l.Desc.NavNodes = val, l.Desc.NavNodes, newVal)),
+            newVal => cmd.Add(new ArrayAddCommand<DynamicNavNode>(val => l.Desc.DynamicNavNodes = val, l.Desc.DynamicNavNodes, newVal)),
             selection, cmd);
 
     public static void AddMovingPlatformMenuHistory(Vector2 pos, Level l, SelectionContext selection, CommandHistory cmd)
@@ -153,7 +153,7 @@ public static class AddObjectPopup
 
         if (maybeAsset.TryGetValue(out AbstractAsset? asset))
         {
-            cmd.Add(new PropChangeCommand<AbstractAsset[]>(val => l.Desc.Assets = val, l.Desc.Assets, [.. l.Desc.Assets, asset]));
+            cmd.Add(new ArrayAddCommand<AbstractAsset>(val => l.Desc.Assets = val, l.Desc.Assets, asset));
             cmd.SetAllowMerge(false);
             selection.Object = asset;
         }

--- a/WallyMapEditor/src/Gui/Windows/HistoryPanel.cs
+++ b/WallyMapEditor/src/Gui/Windows/HistoryPanel.cs
@@ -8,11 +8,11 @@ public static class HistoryPanel
     private static bool _open = false;
     public static bool Open { get => _open; set => _open = value; }
 
-    public static void Show(CommandHistory history)
+    public static void Show(CommandHistory history, SelectionContext selection)
     {
         ImGui.Begin("History", ref _open, ImGuiWindowFlags.NoDocking);
 
-        if (ImGui.Button("Undo##history")) history.Undo();
+        if (ImGui.Button("Undo##history")) history.Undo(selection);
         ImGui.SameLine();
         if (ImGui.Button("Redo##history")) history.Redo();
         ImGui.SameLine();

--- a/WallyMapEditor/src/Gui/Windows/HistoryPanel.cs
+++ b/WallyMapEditor/src/Gui/Windows/HistoryPanel.cs
@@ -12,7 +12,7 @@ public static class HistoryPanel
     {
         ImGui.Begin("History", ref _open, ImGuiWindowFlags.NoDocking);
 
-        if (ImGui.Button("Undo##history")) history.Undo(selection);
+        if (ImGui.Button("Undo##history")) history.Undo();
         ImGui.SameLine();
         if (ImGui.Button("Redo##history")) history.Redo();
         ImGui.SameLine();

--- a/WallyMapEditor/src/Gui/Windows/MapOverviewWindow.cs
+++ b/WallyMapEditor/src/Gui/Windows/MapOverviewWindow.cs
@@ -275,10 +275,8 @@ public class MapOverviewWindow
             {
                 if (ImGui.Button($"x##{o.GetHashCode()}"))
                 {
-                    if (selection.Object == o) selection.Object = null;
-
                     T[] result = WmeUtils.RemoveAt(values, i);
-                    cmd.Add(new PropChangeCommand<T[]>(changeCommand, values, result));
+                    cmd.Add(new ArrayRemoveCommand<T>(changeCommand, result, values[i]));
                     cmd.SetAllowMerge(false);
                     _propChanged |= true;
                 }

--- a/WallyMapEditor/src/SelectionContext.cs
+++ b/WallyMapEditor/src/SelectionContext.cs
@@ -9,6 +9,7 @@ public class SelectionContext
     public bool IsChildOf(object? o) => Object switch
     {
         AbstractAsset a => o == a.Parent || IsChildOf(a.Parent),
+        AbstractCollision c => o == c.Parent,
         AbstractItemSpawn i => o == i.Parent,
         Respawn r => o == r.Parent,
         NavNode n => o == n.Parent,

--- a/WallyMapEditor/src/SelectionContext.cs
+++ b/WallyMapEditor/src/SelectionContext.cs
@@ -1,6 +1,18 @@
+using WallyMapSpinzor2;
+
 namespace WallyMapEditor;
 
 public class SelectionContext
 {
     public object? Object { get; set; }
+
+    public bool IsChildOf(object? o) => Object switch
+    {
+        AbstractAsset a => o == a.Parent || IsChildOf(a.Parent),
+        AbstractItemSpawn i => o == i.Parent,
+        Respawn r => o == r.Parent,
+        NavNode n => o == n.Parent,
+        // keyframes can't be selected. AbstractKeyFrame k => o == k.Parent || IsChildOf(k.Parent),
+        _ => false,
+    };
 }


### PR DESCRIPTION
This adds two new commands, ArrayAddCommand and ArrayRemoveCommand. These can be used when a selectable object is removed or added from an array. ArrayAddCommand will deselect an object when it doesn't exist anymore when undone. ArrayRemoveCommand deselects when the selected object doesn't exist anymore after the command gets executed

Closes #39 