### PR TITLE
remove many casts from double to float

### DIFF
--- a/WallyMapEditor/src/Gui/Overlays/Components/DragBox.cs
+++ b/WallyMapEditor/src/Gui/Overlays/Components/DragBox.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-using WallyMapSpinzor2;
 using Raylib_cs;
 
 namespace WallyMapEditor;

--- a/WallyMapEditor/src/Gui/Overlays/Components/DragBox.cs
+++ b/WallyMapEditor/src/Gui/Overlays/Components/DragBox.cs
@@ -53,7 +53,7 @@ public class DragBox(double x, double y, double w, double h)
             Dragging = true;
         }
 
-        if (Dragging) Middle = (worldPos.X + _mouseDragOffset.Item1, worldPos.Y + _mouseDragOffset.Item2);
+        if (Dragging) Middle = (worldX + _mouseDragOffset.Item1, worldY + _mouseDragOffset.Item2);
     }
 
     // Remove unused parameter 'data' if it is not part of a shipped public API [WallyMapEditor]

--- a/WallyMapEditor/src/Gui/Overlays/ParentAssetOverlay.cs
+++ b/WallyMapEditor/src/Gui/Overlays/ParentAssetOverlay.cs
@@ -32,7 +32,7 @@ public class ParentAssetOverlay(AbstractAsset asset) : IOverlay
         Transform parent = AssetOverlay.FullTransform(asset.Parent, data.Context);
         (Position.X, Position.Y) = (RotatePoint.X, RotatePoint.Y) = (parent.TranslateX + asset.X, parent.TranslateY + asset.Y);
         (ScaleGizmo.X, ScaleGizmo.Y) = (Position.X, Position.Y);
-        ScaleGizmo.Rotation = (float)asset.Rotation;
+        ScaleGizmo.Rotation = asset.Rotation;
 
         ScaleGizmo.Update(data, asset.ScaleX, asset.ScaleY, true);
         RotatePoint.Update(data, !ScaleGizmo.Dragging, asset.Rotation * Math.PI / 180);

--- a/WallyMapEditor/src/Gui/Popups/AddObjectPopup.cs
+++ b/WallyMapEditor/src/Gui/Popups/AddObjectPopup.cs
@@ -25,74 +25,75 @@ public static class AddObjectPopup
 
         ImGui.SeparatorText("Add new object");
 
-        if (ImGui.BeginMenu("Collisions")) { AddDynamicCollisionMenuHistory(NewPos, l, selection, cmd); ImGui.EndMenu(); }
-        if (ImGui.BeginMenu("ItemSpawns")) { AddDynamicItemSpawnMenuHistory(NewPos, l, selection, cmd); ImGui.EndMenu(); }
-        if (ImGui.BeginMenu("Respawns")) { AddDynamicRespawnMenuHistory(NewPos, l, selection, cmd); ImGui.EndMenu(); }
-        if (ImGui.BeginMenu("Platforms")) { AddMovingPlatformMenuHistory(NewPos, l, selection, cmd); ImGui.EndMenu(); }
-        if (ImGui.BeginMenu("NavNodes")) { AddDynamicNavNodeMenuHistory(NewPos, l, selection, cmd); ImGui.EndMenu(); }
+        (float posX, float posY) = (NewPos.X, NewPos.Y);
+        if (ImGui.BeginMenu("Collisions")) { AddDynamicCollisionMenuHistory(posX, posY, l, selection, cmd); ImGui.EndMenu(); }
+        if (ImGui.BeginMenu("ItemSpawns")) { AddDynamicItemSpawnMenuHistory(posX, posY, l, selection, cmd); ImGui.EndMenu(); }
+        if (ImGui.BeginMenu("Respawns")) { AddDynamicRespawnMenuHistory(posX, posY, l, selection, cmd); ImGui.EndMenu(); }
+        if (ImGui.BeginMenu("Platforms")) { AddMovingPlatformMenuHistory(posX, posY, l, selection, cmd); ImGui.EndMenu(); }
+        if (ImGui.BeginMenu("NavNodes")) { AddDynamicNavNodeMenuHistory(posX, posY, l, selection, cmd); ImGui.EndMenu(); }
 
         ImGui.EndPopup();
     }
 
-    public static Maybe<AbstractCollision> AddCollisionMenu(Vector2 start, Vector2 end)
+    public static Maybe<AbstractCollision> AddCollisionMenu(double startX, double startY, double endX, double endY)
     {
         Maybe<AbstractCollision> result = new();
         if (ImGui.BeginMenu("Normal Collision"))
         {
-            if (ImGui.MenuItem(nameof(HardCollision))) result = PropertiesWindow.DefaultCollision<HardCollision>(start, end);
-            if (ImGui.MenuItem(nameof(SoftCollision))) result = PropertiesWindow.DefaultCollision<SoftCollision>(start, end);
-            if (ImGui.MenuItem(nameof(NoSlideCollision))) result = PropertiesWindow.DefaultCollision<NoSlideCollision>(start, end);
+            if (ImGui.MenuItem(nameof(HardCollision))) result = PropertiesWindow.DefaultCollision<HardCollision>(startX, startY, endX, endY);
+            if (ImGui.MenuItem(nameof(SoftCollision))) result = PropertiesWindow.DefaultCollision<SoftCollision>(startX, startY, endX, endY);
+            if (ImGui.MenuItem(nameof(NoSlideCollision))) result = PropertiesWindow.DefaultCollision<NoSlideCollision>(startX, startY, endX, endY);
             ImGui.EndMenu();
         }
         if (ImGui.BeginMenu("Bouncy Collision"))
         {
-            if (ImGui.MenuItem(nameof(BouncyHardCollision))) result = PropertiesWindow.DefaultCollision<BouncyHardCollision>(start, end);
-            if (ImGui.MenuItem(nameof(BouncySoftCollision))) result = PropertiesWindow.DefaultCollision<BouncySoftCollision>(start, end);
-            if (ImGui.MenuItem(nameof(BouncyNoSlideCollision))) result = PropertiesWindow.DefaultCollision<BouncyNoSlideCollision>(start, end);
+            if (ImGui.MenuItem(nameof(BouncyHardCollision))) result = PropertiesWindow.DefaultCollision<BouncyHardCollision>(startX, startY, endX, endY);
+            if (ImGui.MenuItem(nameof(BouncySoftCollision))) result = PropertiesWindow.DefaultCollision<BouncySoftCollision>(startX, startY, endX, endY);
+            if (ImGui.MenuItem(nameof(BouncyNoSlideCollision))) result = PropertiesWindow.DefaultCollision<BouncyNoSlideCollision>(startX, startY, endX, endY);
             ImGui.EndMenu();
         }
         if (ImGui.BeginMenu("Special Collision"))
         {
-            if (ImGui.MenuItem(nameof(StickyCollision))) result = PropertiesWindow.DefaultCollision<StickyCollision>(start, end);
-            if (ImGui.MenuItem(nameof(ItemIgnoreCollision))) result = PropertiesWindow.DefaultCollision<ItemIgnoreCollision>(start, end);
-            if (ImGui.MenuItem(nameof(TriggerCollision))) result = PropertiesWindow.DefaultCollision<TriggerCollision>(start, end);
+            if (ImGui.MenuItem(nameof(StickyCollision))) result = PropertiesWindow.DefaultCollision<StickyCollision>(startX, startY, endX, endY);
+            if (ImGui.MenuItem(nameof(ItemIgnoreCollision))) result = PropertiesWindow.DefaultCollision<ItemIgnoreCollision>(startX, startY, endX, endY);
+            if (ImGui.MenuItem(nameof(TriggerCollision))) result = PropertiesWindow.DefaultCollision<TriggerCollision>(startX, startY, endX, endY);
             ImGui.EndMenu();
         }
         if (ImGui.BeginMenu("Gamemode collision"))
         {
-            if (ImGui.MenuItem(nameof(GameModeHardCollision))) result = PropertiesWindow.DefaultCollision<GameModeHardCollision>(start, end);
-            if (ImGui.MenuItem(nameof(PressurePlateCollision))) result = PropertiesWindow.DefaultCollision<PressurePlateCollision>(start, end);
-            if (ImGui.MenuItem(nameof(SoftPressurePlateCollision))) result = PropertiesWindow.DefaultCollision<SoftPressurePlateCollision>(start, end);
-            if (ImGui.MenuItem(nameof(LavaCollision))) result = PropertiesWindow.DefaultCollision<LavaCollision>(start, end);
+            if (ImGui.MenuItem(nameof(GameModeHardCollision))) result = PropertiesWindow.DefaultCollision<GameModeHardCollision>(startX, startY, endX, endY);
+            if (ImGui.MenuItem(nameof(PressurePlateCollision))) result = PropertiesWindow.DefaultCollision<PressurePlateCollision>(startX, startY, endX, endY);
+            if (ImGui.MenuItem(nameof(SoftPressurePlateCollision))) result = PropertiesWindow.DefaultCollision<SoftPressurePlateCollision>(startX, startY, endX, endY);
+            if (ImGui.MenuItem(nameof(LavaCollision))) result = PropertiesWindow.DefaultCollision<LavaCollision>(startX, startY, endX, endY);
             ImGui.EndMenu();
         }
         return result;
     }
 
-    public static Maybe<AbstractItemSpawn> AddItemSpawnMenu(Vector2 pos)
+    public static Maybe<AbstractItemSpawn> AddItemSpawnMenu(double posX, double posY)
     {
         Maybe<AbstractItemSpawn> result = new();
-        if (ImGui.MenuItem(nameof(ItemSpawn))) result = PropertiesWindow.DefaultItemSpawn<ItemSpawn>(pos);
-        if (ImGui.MenuItem(nameof(ItemInitSpawn))) result = PropertiesWindow.DefaultItemSpawn<ItemInitSpawn>(pos);
-        if (ImGui.MenuItem(nameof(TeamItemInitSpawn))) result = PropertiesWindow.DefaultItemSpawn<TeamItemInitSpawn>(pos);
-        if (ImGui.MenuItem(nameof(ItemSet))) result = PropertiesWindow.DefaultItemSpawn<ItemSet>(pos);
+        if (ImGui.MenuItem(nameof(ItemSpawn))) result = PropertiesWindow.DefaultItemSpawn<ItemSpawn>(posX, posY);
+        if (ImGui.MenuItem(nameof(ItemInitSpawn))) result = PropertiesWindow.DefaultItemSpawn<ItemInitSpawn>(posX, posY);
+        if (ImGui.MenuItem(nameof(TeamItemInitSpawn))) result = PropertiesWindow.DefaultItemSpawn<TeamItemInitSpawn>(posX, posY);
+        if (ImGui.MenuItem(nameof(ItemSet))) result = PropertiesWindow.DefaultItemSpawn<ItemSet>(posX, posY);
         return result;
     }
 
-    public static Maybe<AbstractAsset> AddAssetMenu(Vector2 pos, bool allowAsset = false)
+    public static Maybe<AbstractAsset> AddAssetMenu(double posX, double posY, bool allowAsset = false)
     {
         Maybe<AbstractAsset> result = new();
-        if (allowAsset && ImGui.MenuItem("Asset")) result = PropertiesWindow.DefaultAsset(pos);
-        if (ImGui.MenuItem("Platform with AssetName")) result = PropertiesWindow.DefaultPlatformWithAssetName(pos);
-        if (ImGui.MenuItem("Platform without AssetName")) result = PropertiesWindow.DefaultPlatformWithoutAssetName(pos);
+        if (allowAsset && ImGui.MenuItem("Asset")) result = PropertiesWindow.DefaultAsset(posX, posY);
+        if (ImGui.MenuItem("Platform with AssetName")) result = PropertiesWindow.DefaultPlatformWithAssetName(posX, posY);
+        if (ImGui.MenuItem("Platform without AssetName")) result = PropertiesWindow.DefaultPlatformWithoutAssetName(posX, posY);
         return result;
     }
 
-    private static void AddObjectWithDynamicMenuHistory<N, D>(Vector2 pos, string dynName, Func<Vector2, Maybe<N>> normalMenu, Action<N> normalCmdAdd, Action<D> dynamicCmdAdd, SelectionContext selection, CommandHistory cmd)
+    private static void AddObjectWithDynamicMenuHistory<N, D>(double posX, double posY, string dynName, Func<double, double, Maybe<N>> normalMenu, Action<N> normalCmdAdd, Action<D> dynamicCmdAdd, SelectionContext selection, CommandHistory cmd)
         where D : AbstractDynamic<N>, new()
         where N : ISerializable, IDeserializable, IDrawable
     {
-        Maybe<N> maybeItem = normalMenu(pos);
+        Maybe<N> maybeItem = normalMenu(posX, posY);
         if (maybeItem.TryGetValue(out N? item))
         {
             normalCmdAdd(item);
@@ -101,51 +102,51 @@ public static class AddObjectPopup
         }
         if (ImGui.MenuItem(dynName))
         {
-            D dynamic = new() { X = pos.X, Y = pos.Y, Children = [], PlatID = "0" };
+            D dynamic = new() { X = posX, Y = posY, Children = [], PlatID = "0" };
             dynamicCmdAdd(dynamic);
             cmd.SetAllowMerge(false);
             selection.Object = dynamic;
         }
     }
 
-    public static void AddDynamicItemSpawnMenuHistory(Vector2 pos, Level l, SelectionContext selection, CommandHistory cmd) =>
-        AddObjectWithDynamicMenuHistory<AbstractItemSpawn, DynamicItemSpawn>(pos, "DynamicItemSpawn", AddItemSpawnMenu,
+    public static void AddDynamicItemSpawnMenuHistory(double posX, double posY, Level l, SelectionContext selection, CommandHistory cmd) =>
+        AddObjectWithDynamicMenuHistory<AbstractItemSpawn, DynamicItemSpawn>(posX, posY, "DynamicItemSpawn", AddItemSpawnMenu,
             newVal => cmd.Add(new ArrayAddCommand<AbstractItemSpawn>(val => l.Desc.ItemSpawns = val, l.Desc.ItemSpawns, newVal)),
             newVal => cmd.Add(new ArrayAddCommand<DynamicItemSpawn>(val => l.Desc.DynamicItemSpawns = val, l.Desc.DynamicItemSpawns, newVal)),
             selection, cmd);
 
-    public static void AddDynamicRespawnMenuHistory(Vector2 pos, Level l, SelectionContext selection, CommandHistory cmd) =>
-        AddObjectWithDynamicMenuHistory<Respawn, DynamicRespawn>(pos, "DynamicRespawn",
-            position => ImGui.MenuItem("Respawn") ? PropertiesWindow.DefaultRespawn(position) : Maybe<Respawn>.None,
+    public static void AddDynamicRespawnMenuHistory(double posX, double posY, Level l, SelectionContext selection, CommandHistory cmd) =>
+        AddObjectWithDynamicMenuHistory<Respawn, DynamicRespawn>(posX, posY, "DynamicRespawn",
+            (x, y) => ImGui.MenuItem("Respawn") ? PropertiesWindow.DefaultRespawn(x, y) : Maybe<Respawn>.None,
             newVal => cmd.Add(new ArrayAddCommand<Respawn>(val => l.Desc.Respawns = val, l.Desc.Respawns, newVal)),
             newVal => cmd.Add(new ArrayAddCommand<DynamicRespawn>(val => l.Desc.DynamicRespawns = val, l.Desc.DynamicRespawns, newVal)),
             selection, cmd);
 
-    private static Maybe<AbstractCollision> AddCollisionMenu_(Vector2 pos) => AddCollisionMenu(pos, pos with { X = pos.X + 100 });
+    private static Maybe<AbstractCollision> AddCollisionMenu_(double posX, double posY) => AddCollisionMenu(posX, posY, posX + 100, posY);
 
-    public static void AddDynamicCollisionMenuHistory(Vector2 pos, Level l, SelectionContext selection, CommandHistory cmd) =>
-        AddObjectWithDynamicMenuHistory<AbstractCollision, DynamicCollision>(pos, "DynamicCollision", AddCollisionMenu_,
+    public static void AddDynamicCollisionMenuHistory(double posX, double posY, Level l, SelectionContext selection, CommandHistory cmd) =>
+        AddObjectWithDynamicMenuHistory<AbstractCollision, DynamicCollision>(posX, posY, "DynamicCollision", AddCollisionMenu_,
             newVal => cmd.Add(new ArrayAddCommand<AbstractCollision>(val => l.Desc.Collisions = val, l.Desc.Collisions, newVal)),
             newVal => cmd.Add(new ArrayAddCommand<DynamicCollision>(val => l.Desc.DynamicCollisions = val, l.Desc.DynamicCollisions, newVal)),
             selection, cmd);
 
-    public static void AddDynamicNavNodeMenuHistory(Vector2 pos, Level l, SelectionContext selection, CommandHistory cmd) =>
-        AddObjectWithDynamicMenuHistory<NavNode, DynamicNavNode>(pos, "DynamicNavNode",
-            position => ImGui.MenuItem("NavNode") ? PropertiesWindow.DefaultNavNode(position, l.Desc) : Maybe<NavNode>.None,
+    public static void AddDynamicNavNodeMenuHistory(double posX, double posY, Level l, SelectionContext selection, CommandHistory cmd) =>
+        AddObjectWithDynamicMenuHistory<NavNode, DynamicNavNode>(posX, posY, "DynamicNavNode",
+            (x, y) => ImGui.MenuItem("NavNode") ? PropertiesWindow.DefaultNavNode(x, y, l.Desc) : Maybe<NavNode>.None,
             newVal => cmd.Add(new ArrayAddCommand<NavNode>(val => l.Desc.NavNodes = val, l.Desc.NavNodes, newVal)),
             newVal => cmd.Add(new ArrayAddCommand<DynamicNavNode>(val => l.Desc.DynamicNavNodes = val, l.Desc.DynamicNavNodes, newVal)),
             selection, cmd);
 
-    public static void AddMovingPlatformMenuHistory(Vector2 pos, Level l, SelectionContext selection, CommandHistory cmd)
+    public static void AddMovingPlatformMenuHistory(double posX, double posY, Level l, SelectionContext selection, CommandHistory cmd)
     {
-        Maybe<AbstractAsset> maybeAsset = AddAssetMenu(pos, allowAsset: false);
+        Maybe<AbstractAsset> maybeAsset = AddAssetMenu(posX, posY, allowAsset: false);
         if (ImGui.MenuItem("MovingPlatform"))
         {
             maybeAsset = new MovingPlatform()
             {
                 PlatID = "0",
-                X = pos.X,
-                Y = pos.Y,
+                X = posX,
+                Y = posY,
                 Assets = [],
                 ScaleX = 1,
                 ScaleY = 1,

--- a/WallyMapEditor/src/Gui/Properties/AbstractAssetProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/AbstractAssetProps.cs
@@ -89,11 +89,11 @@ partial class PropertiesWindow
         return propChanged;
     }
 
-    public static Asset DefaultAsset(Vector2 pos) => new()
+    public static Asset DefaultAsset(double posX, double posY) => new()
     {
         AssetName = "../BattleHill/SK_Small_Plat.png",
-        X = pos.X,
-        Y = pos.Y,
+        X = posX,
+        Y = posY,
         W = 750,
         H = 175,
     };

--- a/WallyMapEditor/src/Gui/Properties/CollisionProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/CollisionProps.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Numerics;
 using WallyMapSpinzor2;
 using ImGuiNET;
 

--- a/WallyMapEditor/src/Gui/Properties/CollisionProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/CollisionProps.cs
@@ -143,9 +143,9 @@ public partial class PropertiesWindow
         return propChanged;
     }
 
-    public static C DefaultCollision<C>(Vector2 start, Vector2 end) where C : AbstractCollision, new()
+    public static C DefaultCollision<C>(double startX, double startY, double endX, double endY) where C : AbstractCollision, new()
     {
-        C col = new() { X1 = start.X, X2 = end.X, Y1 = start.Y, Y2 = end.Y };
+        C col = new() { X1 = startX, X2 = endX, Y1 = startY, Y2 = endY };
         if (col is AbstractPressurePlateCollision pcol)
         {
             pcol.AssetName = "a__AnimationPressurePlate";
@@ -171,9 +171,7 @@ public partial class PropertiesWindow
 
         if (ImGui.BeginPopup("ChangeType##col"))
         {
-            Vector2 start = new((float)og.X1, (float)og.Y1);
-            Vector2 end = new((float)og.X2, (float)og.Y2);
-            result = AddObjectPopup.AddCollisionMenu(start, end);
+            result = AddObjectPopup.AddCollisionMenu(og.X1, og.Y1, og.X2, og.Y2);
 
             // avoid changing type to the same one
             result = result.NoneIf(col => col.GetType() == og.GetType());

--- a/WallyMapEditor/src/Gui/Properties/DynamicProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/DynamicProps.cs
@@ -86,7 +86,7 @@ public partial class PropertiesWindow
 
         if (ImGui.BeginPopup("AddChild##dynamic"))
         {
-            result = AddObjectPopup.AddCollisionMenu(new(0, 0), new(100, 0));
+            result = AddObjectPopup.AddCollisionMenu(0, 0, 100, 0);
             result.DoIfSome(col => col.Parent = parent);
             ImGui.EndPopup();
         }
@@ -101,7 +101,7 @@ public partial class PropertiesWindow
 
         if (ImGui.BeginPopup("AddChild##dynamic"))
         {
-            result = AddObjectPopup.AddItemSpawnMenu(new(0, 0));
+            result = AddObjectPopup.AddItemSpawnMenu(0, 0);
             result.DoIfSome(col => col.Parent = parent);
             ImGui.EndPopup();
         }
@@ -113,7 +113,7 @@ public partial class PropertiesWindow
         Maybe<Respawn> result = new();
         if (ImGui.Button("Add new respawn"))
         {
-            result = DefaultRespawn(new(0, 0));
+            result = DefaultRespawn(0, 0);
             result.Value.Parent = parent;
         }
         return result;
@@ -124,7 +124,7 @@ public partial class PropertiesWindow
         Maybe<NavNode> result = new();
         if (ImGui.Button("Add new navnode"))
         {
-            result = DefaultNavNode(new(0, 0), desc);
+            result = DefaultNavNode(0, 0, desc);
             result.Value.Parent = parent;
         }
         return result;

--- a/WallyMapEditor/src/Gui/Properties/ItemSpawnProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/ItemSpawnProps.cs
@@ -34,8 +34,7 @@ public partial class PropertiesWindow
 
         if (ImGui.BeginPopup("ChangeType##item"))
         {
-            Vector2 pos = new((float)og.X, (float)og.Y);
-            result = AddObjectPopup.AddItemSpawnMenu(pos).NoneIf(i => i.GetType() == og.GetType());
+            result = AddObjectPopup.AddItemSpawnMenu(og.X, og.Y).NoneIf(i => i.GetType() == og.GetType());
 
             result.DoIfSome(item =>
             {
@@ -52,12 +51,12 @@ public partial class PropertiesWindow
         return result;
     }
 
-    public static T DefaultItemSpawn<T>(Vector2 pos) where T : AbstractItemSpawn, new()
+    public static T DefaultItemSpawn<T>(double posX, double posY) where T : AbstractItemSpawn, new()
     {
         T spawn = new()
         {
-            X = pos.X,
-            Y = pos.Y
+            X = posX,
+            Y = posY
         };
         (spawn.W, spawn.H) = (spawn.DefaultW, spawn.DefaultH);
         if (spawn is ItemSpawn)

--- a/WallyMapEditor/src/Gui/Properties/ItemSpawnProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/ItemSpawnProps.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using WallyMapSpinzor2;
 using ImGuiNET;
 

--- a/WallyMapEditor/src/Gui/Properties/MovingPlatformProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/MovingPlatformProps.cs
@@ -45,7 +45,7 @@ public partial class PropertiesWindow
 
         if (ImGui.BeginPopup("AddChild##moving_platform"))
         {
-            result = AddObjectPopup.AddAssetMenu(new(0, 0));
+            result = AddObjectPopup.AddAssetMenu(0, 0);
             result.DoIfSome(a => a.Parent = parent);
             ImGui.EndPopup();
         }

--- a/WallyMapEditor/src/Gui/Properties/NavNodeProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/NavNodeProps.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Linq;
+using System.Collections.Generic;
 using WallyMapSpinzor2;
 using ImGuiNET;
-using System.Collections.Generic;
-using System.Numerics;
 
 namespace WallyMapEditor;
 

--- a/WallyMapEditor/src/Gui/Properties/NavNodeProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/NavNodeProps.cs
@@ -137,10 +137,10 @@ public partial class PropertiesWindow
     private static bool NavIDExists(int id, LevelDesc ld) =>
         EnumerateNavNodes(ld).Any(n => n.NavID == id);
 
-    public static NavNode DefaultNavNode(Vector2 pos, LevelDesc desc) => new()
+    public static NavNode DefaultNavNode(double posX, double posY, LevelDesc desc) => new()
     {
-        X = pos.X,
-        Y = pos.Y,
+        X = posX,
+        Y = posY,
         NavID = EnumerateNavNodes(desc).Select(n => n.NavID).OrderByDescending(id => id).FirstOrDefault() + 1,
         Path = [],
         Type = NavNodeTypeEnum.A

--- a/WallyMapEditor/src/Gui/Properties/PlatformProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/PlatformProps.cs
@@ -73,29 +73,29 @@ partial class PropertiesWindow
 
         if (ImGui.BeginPopup("AddChild##platform"))
         {
-            result = AddObjectPopup.AddAssetMenu(new(0, 0), true);
+            result = AddObjectPopup.AddAssetMenu(0, 0, true);
             result.DoIfSome(a => a.Parent = parent);
             ImGui.EndPopup();
         }
         return result;
     }
 
-    public static Platform DefaultPlatformWithAssetName(Vector2 pos) => new()
+    public static Platform DefaultPlatformWithAssetName(double posX, double posY) => new()
     {
         InstanceName = "Custom_Platform",
         AssetName = "../BattleHill/SK_Small_Plat.png",
-        X = pos.X,
-        Y = pos.Y,
+        X = posX,
+        Y = posY,
         W = 750,
         H = 175,
     };
 
-    public static Platform DefaultPlatformWithoutAssetName(Vector2 pos) => new()
+    public static Platform DefaultPlatformWithoutAssetName(double posX, double posY) => new()
     {
         InstanceName = "Custom_Platform",
         AssetChildren = [],
-        X = pos.X,
-        Y = pos.Y,
+        X = posX,
+        Y = posY,
         ScaleX = 1,
         ScaleY = 1,
     };

--- a/WallyMapEditor/src/Gui/Properties/PlatformProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/PlatformProps.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using WallyMapSpinzor2;
 using ImGuiNET;
 

--- a/WallyMapEditor/src/Gui/Properties/RespawnProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/RespawnProps.cs
@@ -33,5 +33,5 @@ public partial class PropertiesWindow
         return propChanged;
     }
 
-    public static Respawn DefaultRespawn(Vector2 pos) => new() { X = pos.X, Y = pos.Y };
+    public static Respawn DefaultRespawn(double posX, double posY) => new() { X = posX, Y = posY };
 }

--- a/WallyMapEditor/src/Gui/Properties/RespawnProps.cs
+++ b/WallyMapEditor/src/Gui/Properties/RespawnProps.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using WallyMapSpinzor2;
 using ImGuiNET;
 

--- a/WallyMapEditor/src/Gui/Windows/MapOverviewWindow.cs
+++ b/WallyMapEditor/src/Gui/Windows/MapOverviewWindow.cs
@@ -193,14 +193,14 @@ public class MapOverviewWindow
 
         ImGui.Separator();
 
-        void addButton(string id, Action<Vector2> menu)
+        void addButton(string id, Action<double, double> menu)
         {
             if (ImGui.Button($"+##{id}"))
                 ImGui.OpenPopup($"AddObject_{id}");
 
             if (ImGui.BeginPopup($"AddObject_{id}"))
             {
-                menu(new((float)(l.Desc.CameraBounds.X + l.Desc.CameraBounds.W / 2), (float)(l.Desc.CameraBounds.Y + l.Desc.CameraBounds.H / 2)));
+                menu(l.Desc.CameraBounds.X + l.Desc.CameraBounds.W / 2, l.Desc.CameraBounds.Y + l.Desc.CameraBounds.H / 2);
                 ImGui.EndPopup();
             }
         }
@@ -220,35 +220,35 @@ public class MapOverviewWindow
             if (l.Desc.LevelAnimations.Length > 0) ImGui.Separator();
             ShowSelectableList(l.Desc.LevelAnimations, selection, val => l.Desc.LevelAnimations = val, cmd, movable: true);
         },
-        () => addButton("asset", pos => AddObjectPopup.AddMovingPlatformMenuHistory(pos, l, selection, cmd)));
+        () => addButton("asset", (x, y) => AddObjectPopup.AddMovingPlatformMenuHistory(x, y, l, selection, cmd)));
 
         ImGuiExt.HeaderWithWidget("Collisions##overview", () =>
         {
             ShowSelectableList(l.Desc.Collisions, selection, val => l.Desc.Collisions = val, cmd);
             ShowSelectableList(l.Desc.DynamicCollisions, selection, val => l.Desc.DynamicCollisions = val, cmd);
         },
-        () => addButton("collision", pos => AddObjectPopup.AddDynamicCollisionMenuHistory(pos, l, selection, cmd)));
+        () => addButton("collision", (x, y) => AddObjectPopup.AddDynamicCollisionMenuHistory(x, y, l, selection, cmd)));
 
         ImGuiExt.HeaderWithWidget("Respawns##overview", () =>
         {
             ShowSelectableList(l.Desc.Respawns, selection, val => l.Desc.Respawns = val, cmd);
             ShowSelectableList(l.Desc.DynamicRespawns, selection, val => l.Desc.DynamicRespawns = val, cmd);
         },
-        () => addButton("respawn", pos => AddObjectPopup.AddDynamicRespawnMenuHistory(pos, l, selection, cmd)));
+        () => addButton("respawn", (x, y) => AddObjectPopup.AddDynamicRespawnMenuHistory(x, y, l, selection, cmd)));
 
         ImGuiExt.HeaderWithWidget("Item Spawns##overview", () =>
         {
             ShowSelectableList(l.Desc.ItemSpawns, selection, val => l.Desc.ItemSpawns = val, cmd);
             ShowSelectableList(l.Desc.DynamicItemSpawns, selection, val => l.Desc.DynamicItemSpawns = val, cmd);
         },
-        () => addButton("itemspawn", pos => AddObjectPopup.AddDynamicItemSpawnMenuHistory(pos, l, selection, cmd)));
+        () => addButton("itemspawn", (x, y) => AddObjectPopup.AddDynamicItemSpawnMenuHistory(x, y, l, selection, cmd)));
 
         ImGuiExt.HeaderWithWidget("NavNodes##overview", () =>
         {
             ShowSelectableList(l.Desc.NavNodes, selection, val => l.Desc.NavNodes = val, cmd);
             ShowSelectableList(l.Desc.DynamicNavNodes, selection, val => l.Desc.DynamicNavNodes = val, cmd);
         },
-        () => addButton("navnode", pos => AddObjectPopup.AddDynamicNavNodeMenuHistory(pos, l, selection, cmd)));
+        () => addButton("navnode", (x, y) => AddObjectPopup.AddDynamicNavNodeMenuHistory(x, y, l, selection, cmd)));
 
         if (ImGui.CollapsingHeader("Volumes##overview"))
         {

--- a/WallyMapEditor/src/Gui/Windows/ViewportWindow.cs
+++ b/WallyMapEditor/src/Gui/Windows/ViewportWindow.cs
@@ -1,5 +1,4 @@
 using System.Numerics;
-
 using Raylib_cs;
 using ImGuiNET;
 using rlImGui_cs;


### PR DESCRIPTION
most importantly, avoid casting to float when changing col type. this prevents float point inaccuracies from turning a wall collision into a non-wall collision, since the game has no margin when checking the normal.